### PR TITLE
Fix performance of dictionary check for longer passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
+## [0.1.9] - 2023-01-27
+- [#6] [#7] Security/Performance fix to vulnerability to DoS attacks.
+
 ## [0.1.8] - 2023-01-22
 - How to find information on translations on README.
 - Drop automatic tests on ruby 2.5 (It still works on it but development gems are failing to build).
 - Update dev gems to prepare to test on Ruby 3.1 and 3.2. (mini_racer, rubocop and bundler)
-- Fix Style/RedundantStringEscape on frequency_lists.rb
-- Add automated tests for Ruby 3.1 and 3.2
-- Add MFA requirement on release
-- Trim non-production files from final gem
+- Fix Style/RedundantStringEscape on frequency_lists.rb.
+- Add automated tests for Ruby 3.1 and 3.2.
+- Add MFA requirement on release.
+- Trim non-production files from final gem.
 
 ## [0.1.7] - 2021-06-12
 - Ported original specs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zxcvbn (0.1.8)
+    zxcvbn (0.1.9)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,20 @@
 
 Ruby port of Dropbox's [zxcvbn.js](https://github.com/dropbox/zxcvbn) JavaScript library running completely in Ruby (no need to load execjs or libv8).
 
-The intention is to provide an option 100% Ruby solution with all the same features and same results (or as close to the original JS function as possible).
+### Goals:
+- Exact same results as [dropbox/zxcvbn.js (Version 4.4.2)](https://github.com/dropbox/zxcvbn). If **result compatibility** is found or made different a major version will be bumped so no one is caught off guard.
+- Parity of features to [dropbox/zxcvbn.js (Version 4.4.2)](https://github.com/dropbox/zxcvbn) interface.
+- 100% native Ruby solution: **No Javascript Runtime**.
+
+### Compatible with [zxcvbn-js](https://github.com/bitzesty/zxcvbn-js) and [zxcvbn-ruby](https://github.com/envato/zxcvbn-ruby)
+
+This gem include compatibility interfaces so it can be used as a drop-in substitution both of the most popular alternatives `zxcvbn-js` and `zxcvbn-ruby`). Besides `Zxcvbn.zxcvbn` you can just call `Zxcvbn.test` or use `Zxcvbn::Tester.new` the same way as you would if you were using any of them.
+
+|                                    | `zxcvbn-rb`            | `zxcvbn-js`            | `zxcvbn-ruby`          |
+|------------------------------------|------------------------|------------------------|------------------------|
+| Results match `zxcvbn.js (V4.4.2)` | :white_check_mark: yes | :white_check_mark: yes | :x: no                 |
+| Run without Javascript Runtime     | :white_check_mark: yes | :x: no                 | :white_check_mark: yes |
+| Interface compatibility with others| :white_check_mark: yes | :x: no                 | :x: no                 |
 
 ## Installation
 
@@ -70,10 +83,6 @@ Zxcvbn.zxcvbn("password")
   }
 }
 ```
-
-### Compatible with `zxcvbn-js` and `zxcvbn-ruby`
-
-This gem include a compatible interface so it can be used as a drop-in substitution for `zxcvbn-js` or `zxcvbn-ruby`. You can just call `Zxcvbn.test` or use `Zxcvbn::Tester.new` the same way as you would if you were using `zxcvbn-js` or `zxcvbn-ruby`.
 
 ### Note about translations (i18n, gettext, etc...)
 Check the [wiki](https://github.com/formigarafa/zxcvbn-rb/wiki) for more details on how to handle translations.

--- a/lib/zxcvbn/version.rb
+++ b/lib/zxcvbn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Zxcvbn
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end


### PR DESCRIPTION
Fixes #6 and makes the algorithm to have an linear response time in relation to the size of the password instead of an exponential as it used to as reported by https://github.com/twosixlabs/acsploit.

Thanks to @Tostino for bringing this up.