### PR TITLE
Feature/add configuration option for custom dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ This gem include compatibility interfaces so it can be used as a drop-in substit
 | Run without Javascript Runtime     | :white_check_mark: yes | :x: no                 | :white_check_mark: yes |
 | Interface compatibility with others| :white_check_mark: yes | :x: no                 | :x: no                 |
 
+## Configuration
+
+Zxcvbn allows you to load custom dictionaries to enhance the password strength estimation.
+
+To load dictionaries, use the following syntax:
+
+```ruby
+Zxcvbn.configure do |config|
+  config.add_dictionary('path/to/custom_dictionary.txt')
+  # Add more dictionaries as needed
+end
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "zxcvbn/config"
 require_relative "zxcvbn/adjacency_graphs"
 require_relative "zxcvbn/frequency_lists"
 require_relative "zxcvbn/matching"

--- a/lib/zxcvbn/config.rb
+++ b/lib/zxcvbn/config.rb
@@ -1,0 +1,23 @@
+module Zxcvbn
+  module Config
+    extend self
+
+    def add_dictionary(path)
+      data = File.read(path)
+      lines = data.split("\n").map(&:strip)
+      filename = File.basename(path, ".*")
+      new_ranked_dictionary = Hash[filename, Zxcvbn::Matching.build_ranked_dict(lines.join(",").split(","))]
+      Zxcvbn::Matching::RANKED_DICTIONARIES.merge! new_ranked_dictionary
+    end
+  end
+
+  class << self
+    def configure
+      block_given? ? yield(Config) : Config
+    end
+
+    def config
+      Config
+    end
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe "Zxcvbn::Config" do
+  describe "#add_dictionary" do
+    let(:dictionary_path) { 'custom_dictionary.txt' }
+    let(:dictionary_contents) { "password_1\npassword_2\npassword_3" }
+
+    before do
+      allow(File).to receive(:read).with(dictionary_path).and_return(dictionary_contents)
+    end
+
+    it "adds a custom dictionary to RANKED_DICTIONARIES" do
+      Zxcvbn.config.add_dictionary(dictionary_path)
+
+      expected_dictionary = {
+        'custom_dictionary' => {
+          'password_1' => 1,
+          'password_2' => 2,
+          'password_3' => 3
+        }
+      }
+
+      expect(Zxcvbn::Matching::RANKED_DICTIONARIES).to include(expected_dictionary)
+    end
+  end
+
+  describe ".configure" do
+
+    context "when called with a block" do
+      it "yields the Config module" do
+        expect { |b| Zxcvbn.configure(&b) }.to yield_with_args(Zxcvbn::Config)
+      end
+    end
+
+    context "when called without a block" do
+      it "returns the Config module" do
+        expect(Zxcvbn.configure).to eq(Zxcvbn.config)
+      end
+    end
+  end
+
+  describe ".config" do
+    it "returns the Config module" do
+      expect(Zxcvbn.config).to eq(Zxcvbn.config)
+    end
+  end
+end


### PR DESCRIPTION
**Description**

This pull request adds a new configuration option to the Zxcvbn library, allowing users to customize to add custom dictionaries in the form of a text file.

**Changes Made**

- Added a new config module
- Added spec for the config
- Added config option to the readme