### PR TITLE
Remove OpenStruct usage

### DIFF
--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -20,7 +20,7 @@ module Zxcvbn
     :crack_times_display,
     :score,
     :feedback,
-    keyword_init: true,
+    keyword_init: true
   )
 
   def self.zxcvbn(password, user_inputs = [])

--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -10,6 +10,18 @@ require_relative "zxcvbn/version"
 
 module Zxcvbn
   class Error < StandardError; end
+  Result = Struct.new(
+    :password,
+    :guesses,
+    :guesses_log10,
+    :sequence,
+    :calc_time,
+    :crack_times_seconds,
+    :crack_times_display,
+    :score,
+    :feedback,
+    keyword_init: true,
+  )
 
   def self.zxcvbn(password, user_inputs = [])
     start = (Time.now.to_f * 1000).to_i
@@ -25,7 +37,7 @@ module Zxcvbn
   end
 
   def self.test(password, user_inputs = [])
-    OpenStruct.new(Zxcvbn.zxcvbn(password, user_inputs)) # rubocop:disable Style/OpenStructUse
+    Result.new(Zxcvbn.zxcvbn(password, user_inputs))
   end
 
   class Tester

--- a/spec/zxcvbn_spec.rb
+++ b/spec/zxcvbn_spec.rb
@@ -236,9 +236,9 @@ RSpec.describe Zxcvbn do
     normal_result = Zxcvbn.zxcvbn("@lfred2004", ["alfred"]).reject { |k, _v| ["calc_time"].include? k }
     result1 = Zxcvbn.test("@lfred2004", ["alfred"])
     result2 = Zxcvbn::Tester.new.test("@lfred2004", ["alfred"])
-    expect(result1).to be_a(OpenStruct) # rubocop:disable Style/OpenStructUse
+    expect(result1).to be_a(Zxcvbn::Result)
     expect(result1.to_h.transform_keys(&:to_s).reject { |k, _v| ["calc_time"].include? k }).to eq(normal_result)
-    expect(result2).to be_a(OpenStruct) # rubocop:disable Style/OpenStructUse
+    expect(result2).to be_a(Zxcvbn::Result)
     expect(result2.to_h.transform_keys(&:to_s).reject { |k, _v| ["calc_time"].include? k }).to eq(normal_result)
   end
 end


### PR DESCRIPTION
Hello! I'm seeing performance warnings show up when using zxcvbn-rb in Ruby 3.3.0 due to the usage of OpenStruct, which is now [discouraged](https://ruby-doc.org/3.3.5/stdlibs/ostruct/OpenStruct.html#class-OpenStruct-label-Caveats).

Running specs or an application that uses zxcvbn-rb with the following Ruby flag will print the warnings:

```
RUBYOPT="-W:performance" rspec

zxcvbn-0.1.9/lib/zxcvbn.rb:34: warning: OpenStruct use is discouraged for performance reasons
# ...
```

This PR removes the OpenStruct in favor of a struct that defines the fields used in the result.