### PR TITLE
Optimize both allocated and retained memory usage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,8 +63,8 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
-  arm64-darwin-21
-  x86_64-darwin-23
+  arm64-darwin
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/zxcvbn/frequency_lists.rb
+++ b/lib/zxcvbn/frequency_lists.rb
@@ -13,7 +13,7 @@ module Zxcvbn
         f.each_line do |line|
           next if line.nil?
 
-          main_enum << line.strip!
+          main_enum << line.strip!.freeze
         end
       end
     end

--- a/lib/zxcvbn/matching.rb
+++ b/lib/zxcvbn/matching.rb
@@ -1,29 +1,14 @@
 # frozen_string_literal: true
 
 module Zxcvbn
-  class RankedDict
-    def initialize(words)
-      @words = words.to_a.freeze
-      @sorted = Set.new(@words).freeze
-    end
-
-    def key?(word)
-      @sorted.include? word
-    end
-
-    def keys
-      @words
-    end
-
-    def [](word)
-      # rank starts at 1, not 0
-      @words.index(word) + 1
-    end
-  end
-
   module Matching
     def self.build_ranked_dict(ordered_list)
-      RankedDict.new(ordered_list)
+      result = {}
+      # rank starts at 1, not 0
+      ordered_list.each_with_index do |word, idx|
+        result[word] = idx + 1
+      end
+      result
     end
 
     RANKED_DICTIONARIES = Zxcvbn.frequency_lists.transform_values do |lst|
@@ -213,7 +198,7 @@ module Zxcvbn
 
     def self.build_user_input_dictionary(user_inputs_or_dict)
       # optimization: if we receive a hash, we've been given the dict back (from the repeat matcher)
-      return user_inputs_or_dict if user_inputs_or_dict.is_a?(RankedDict)
+      return user_inputs_or_dict if user_inputs_or_dict.is_a?(Hash)
 
       sanitized_inputs = []
       user_inputs_or_dict.each do |arg|

--- a/lib/zxcvbn/matching.rb
+++ b/lib/zxcvbn/matching.rb
@@ -31,7 +31,7 @@ module Zxcvbn
     end
 
     RANKED_DICTIONARIES_MAX_WORD_SIZE = RANKED_DICTIONARIES.transform_values do |word_scores|
-      word_scores.keys.max_by(&:size).size
+      word_scores.each_key.max_by(&:size)&.size || 0
     end
 
     GRAPHS = {
@@ -174,7 +174,7 @@ module Zxcvbn
       len = password.length
       password_lower = password.downcase
       longest_word_size = RANKED_DICTIONARIES_MAX_WORD_SIZE.fetch(dictionary_name) do
-        ranked_dict.keys.max_by(&:size)&.size || 0
+        ranked_dict.each_key.max_by(&:size)&.size || 0
       end
       search_width = [longest_word_size, len].min
       (0...len).each do |i|

--- a/lib/zxcvbn/matching.rb
+++ b/lib/zxcvbn/matching.rb
@@ -1,14 +1,29 @@
 # frozen_string_literal: true
 
 module Zxcvbn
+  class RankedDict
+    def initialize(words)
+      @words = words.to_a.freeze
+      @sorted = Set.new(@words).freeze
+    end
+
+    def key?(word)
+      @sorted.include? word
+    end
+
+    def keys
+      @words
+    end
+
+    def [](word)
+      # rank starts at 1, not 0
+      @words.index(word) + 1
+    end
+  end
+
   module Matching
     def self.build_ranked_dict(ordered_list)
-      result = {}
-      # rank starts at 1, not 0
-      ordered_list.each_with_index do |word, idx|
-        result[word] = idx + 1
-      end
-      result
+      RankedDict.new(ordered_list)
     end
 
     RANKED_DICTIONARIES = Zxcvbn.frequency_lists.transform_values do |lst|
@@ -198,7 +213,7 @@ module Zxcvbn
 
     def self.build_user_input_dictionary(user_inputs_or_dict)
       # optimization: if we receive a hash, we've been given the dict back (from the repeat matcher)
-      return user_inputs_or_dict if user_inputs_or_dict.is_a?(Hash)
+      return user_inputs_or_dict if user_inputs_or_dict.is_a?(RankedDict)
 
       sanitized_inputs = []
       user_inputs_or_dict.each do |arg|

--- a/lib/zxcvbn/scoring.rb
+++ b/lib/zxcvbn/scoring.rb
@@ -9,7 +9,7 @@ module Zxcvbn
       graph.each_value do |neighbors|
         average += neighbors.count { |n| n }.to_f
       end
-      average /= graph.keys.size.to_f
+      average /= graph.size.to_f
       average
     end
 
@@ -324,8 +324,8 @@ module Zxcvbn
     # slightly different for keypad/mac keypad, but close enough
     KEYPAD_AVERAGE_DEGREE = calc_average_degree(ADJACENCY_GRAPHS["keypad"]).freeze
 
-    KEYBOARD_STARTING_POSITIONS = ADJACENCY_GRAPHS["qwerty"].keys.size
-    KEYPAD_STARTING_POSITIONS = ADJACENCY_GRAPHS["keypad"].keys.size
+    KEYBOARD_STARTING_POSITIONS = ADJACENCY_GRAPHS["qwerty"].size
+    KEYPAD_STARTING_POSITIONS = ADJACENCY_GRAPHS["keypad"].size
 
     def self.spatial_guesses(match)
       if ["qwerty", "dvorak"].include?(match["graph"])


### PR DESCRIPTION
Inspired by #12, #13, and #15, I decided to play with this a bit and see if memory optimization could be taken even farther. Turns out, it seems so.

### Experiment 1

Freeze the strings read from `frequency_lists/*.txt` (great idea to make this external, BTW). See `frequency_lists.rb:16`.

This reduced initial memory allocations a good bit.


### Experiment 2

Avoid allocating an Array for `keys` when computing `RANKED_DICTIONARIES_MAX_WORD_SIZE`.

In `matching.rb:34`, this change would have been to replace

```ruby
word_scores.keys.max_by(&:size).size
```
with
```ruby
max_word = 0
word_scores.each_key { |k| max_word = k.size if k.size > max_word }
max_word
```

This reduced initial allocations a little bit more. However, in combo with experiment 3, it doesn't seem necessary.


### Experiment 3

Change storage of ranked dictionaries from a Hash to a dual Array + Set, using a new RankedDict class as a shim of sorts. The Array is used as both the original list of keys and to determine the rank aka index. The Set is used for fast lookups.

Using Array alone takes a _tiny_ bit less memory, but is 10x slower for lookups.

By adding a new `RankedDict` class, almost nothing else had to change. It defines just enough methods to provide compatibility with the prior existing usage of Hash. I know one goal of the project is to minimize changes with the JS implementation and this seemed to be the least invasive way to swap out the data structures.

This reduces initial allocations even further over Experiment 1 alone and also reduces retained memory a fair bit.


### Results

This PR includes experiments 1 and 3. With experiment 3, experiment 2 didn't seem to be needed since it's now operating on the array from RankedDict anyway.

Overall performance seems to be about the same. 

The memory savings are notable, at least on MRI Ruby 3.3. Not sure how it might compare to other Rubies.

**Initial allocations: reduced by 57%
Retained memory: reduced by 33%**

Memory measurements generated with `derailed bundle:objects` on a local project that uses `zxcvbn-rb`.

#### Before

```
allocated memory by gem
  12030398  zxcvbn-rb/lib
allocated memory by file
   7940701  ~/zxcvbn-rb/lib/zxcvbn/matching.rb
   3838642  ~/zxcvbn-rb/lib/zxcvbn/frequency_lists.rb
retained memory by gem
   7123076  zxcvbn-rb/lib
retained memory by file
   7081372  ~/zxcvbn-rb/lib/zxcvbn/matching.rb
```

#### After

```
allocated memory by gem
   5166998  zxcvbn-rb/lib
allocated memory by file
   3842002  ~/zxcvbn-rb/lib/zxcvbn/frequency_lists.rb
   1073781  ~/zxcvbn-rb/lib/zxcvbn/matching.rb
retained memory by gem
   4776228  zxcvbn-rb/lib
retained memory by file
   3771576  ~/zxcvbn-rb/lib/zxcvbn/frequency_lists.rb
    964564  ~/zxcvbn-rb/lib/zxcvbn/matching.rb
```
